### PR TITLE
This is a bug resulting from Ubuntu providing incorrect metadata to pip

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ isort==4.2.5
 page-objects==1.1.0
 pexpect==4.1.0
 pickleshare==0.7.2
-pkg-resources==0.0.0
 ptyprocess==0.5.1
 py==1.4.31
 pytest==2.9.2


### PR DESCRIPTION
This line seems to break things in some cases when trying to install packages with a requirements.txt file generated with pip freeze that includes the pkg-resources==0.0.0 line
It seems to be some "implicitly installed package".

There is a follow-up bug with Ubuntu:
https://bugs.launchpad.net/ubuntu/+source/python-pip/+bug/1635463